### PR TITLE
[PR] Reset the global WP_Query when using the events shortcode

### DIFF
--- a/includes/shortcode-events.php
+++ b/includes/shortcode-events.php
@@ -62,6 +62,9 @@ class WSU_COB_Events {
 			$content = ob_get_contents();
 			ob_end_clean();
 		}
+
+		wp_reset_query();
+
 		return $content;
 	}
 }


### PR DESCRIPTION
This was blocking menus from highlighting properly in the navigation
when a page embedded event information
