### PR TITLE
[PR] Only force remove events from page list in main query

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -168,7 +168,7 @@ function cob_remove_events_from_edit( $query ) {
 		return;
 	}
 
-	if ( 'edit' === get_current_screen()->base && 'tribe_events' !== get_current_screen()->post_type ) {
+	if ( 'edit' === get_current_screen()->base && 'tribe_events' !== get_current_screen()->post_type && $query->is_main_query() ) {
 		$query->set( 'post_type', get_current_screen()->post_type );
 	}
 


### PR DESCRIPTION
The Events Calendar stomps its way into the page listing, so we
stomped back in 2409beceb360

Unfortunately, this stomped out our Last Updated column as well
since it searches for revisions and was being told to only use
pages all of a sudden.

Adding a check for is_main_query() ensures that we only stomp the
big one.

Fixes #35
