### PR TITLE
[PR] Fixes after a broken link report

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -128,6 +128,20 @@ function cob_filter_post_type_link( $post_link, $post ) {
 	return $post_link;
 }
 
+add_filter( 'term_link', 'cob_filter_term_link', 10 );
+/**
+ * Filter category links attached to events to match our slug.
+ *
+ * @param $term_link
+ *
+ * @return mixed
+ */
+function cob_filter_term_link( $term_link ) {
+	$term_link = str_replace( home_url( '/events/category/' ), home_url( '/news-events/calendar/category/' ), $term_link );
+
+	return $term_link;
+}
+
 add_filter( 'generate_rewrite_rules', 'cob_filter_rewrite_rules', 11 );
 /**
  * Replace rewrite rules provided by The Events Calendar with our own to support


### PR DESCRIPTION
- Filter category links for events to match our structure.
- Remove all comment and other extra feed links generated by WordPress.
