### PR TITLE
[PR] Update JavaScript used to consume the WP REST API for v2 support

### DIFF
--- a/js/display-json-feeds.js
+++ b/js/display-json-feeds.js
@@ -7,7 +7,7 @@
 
 			var json_html = '<ul>';
 			for ( var item in source_data ) {
-				json_html += '<li><a href="' + source_data[item ].link + '">' + source_data[item].title + '</a></li>';
+				json_html += '<li><a href="' + source_data[item ].link + '">' + source_data[item].title.rendered + '</a></li>';
 			}
 			json_html += '</ul>';
 			container.append( json_html );
@@ -19,8 +19,8 @@
 			var source_data = window[source_data_obj];
 
 			for ( var item in source_data ) {
-				var cob_excerpt = source_data[item ].content.split('<!--more-->');
-				container.append( '<div><h2><a href="' + source_data[item ].link + '">' + source_data[item].title + '</a></h2>' + cob_excerpt[0] + '</div>');
+				var cob_excerpt = source_data[item ].content.rendered.split('<!--more-->');
+				container.append( '<div><h2><a href="' + source_data[item ].link + '">' + source_data[item].title.rendered + '</a></h2>' + cob_excerpt[0] + '</div>');
 			}
 		});
 	}


### PR DESCRIPTION
This will need to be merged and released along with the update to v2 for the platform.