### PR TITLE
[PR] Don't mark ancestors as active

### DIFF
--- a/spine/site-navigation.php
+++ b/spine/site-navigation.php
@@ -23,7 +23,9 @@
 			'whitelist_top'   => null, // optional string or array of post names to whitelist for top level
 			'echo'            => 1 // whether to display immediately or return
 		);
+		remove_filter( 'bu_navigation_filter_pages', 'bu_navigation_filter_pages_ancestors' );
 		bu_navigation_display_primary( $bu_nav_args );
+		add_filter( 'bu_navigation_filter_pages', 'bu_navigation_filter_pages_ancestors' );
 	} else {
 		$spine_site_args = array(
 			'theme_location'  => 'site',


### PR DESCRIPTION
This corrects an issue where the Spine would apply overly active active styles to the navigation.

See https://github.com/washingtonstateuniversity/WSUWP-spine-parent-theme/pull/319