### PR TITLE
[PR] Use `active` for custom Spine output, remove default handling

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -32,7 +32,7 @@ function cob_theme_setup() {
 
 add_filter( 'bu_navigation_filter_item_attrs', 'cob_bu_navigation_filter_item_attrs', 10, 2 );
 /**
- * Filter the list item classes to manually add current and dogeared when necessary.
+ * Filter the list item classes to manually add active when necessary.
  *
  * @param array   $item_classes List of classes assigned to the list item.
  * @param WP_Post $page         Post object for the current page.
@@ -42,20 +42,13 @@ add_filter( 'bu_navigation_filter_item_attrs', 'cob_bu_navigation_filter_item_at
 function cob_bu_navigation_filter_item_attrs( $item_classes, $page ) {
 	global $wp_query;
 
-	if ( in_array( 'current_page_item', $item_classes ) || in_array( 'current_page_parent', $item_classes ) ) {
-		$item_classes[] = 'current';
-	}
-
-	if ( is_singular() && get_the_ID() == $page->ID ) {
-		$item_classes[] = 'dogeared';
-	}
-
 	if ( isset( $wp_query->tribe_is_event ) && true === $wp_query->tribe_is_event ) {
 		if ( isset( $page->url ) && home_url( '/news-events/calendar/' ) === $page->url ) {
-			$item_classes[] = 'current dogeared';
+			$item_classes[] = 'active';
 		}
+
 		if ( isset( $page->url ) && home_url( '/news-events/' ) === $page->url ) {
-			$item_classes[] = 'current';
+			$item_classes[] = 'active';
 		}
 	}
 


### PR DESCRIPTION
Remove some of the default logic that's already being handled in
the Spine Parent Theme. Adjust the remaining logic for events URLs
to use the `active` class for proper Spine behavior.