### PR TITLE
Use `get_site()` vs `wsuwp_get_current_site()`

### DIFF
--- a/spine/site-navigation.php
+++ b/spine/site-navigation.php
@@ -2,8 +2,9 @@
 	<?php
 	$output_menu_script = false;
 
-	if ( '/' !== wsuwp_get_current_site()->path && '/dividend/' !== wsuwp_get_current_site()->path ) {
-		$switch_site = get_blog_details( array( 'domain' => wsuwp_get_current_site()->domain, 'path' => '/' ) );
+	$nav_site = get_site();
+	if ( '/' !== $nav_site->path && '/dividend/' !== $nav_site->path ) {
+		$switch_site = get_blog_details( array( 'domain' => $nav_site->domain, 'path' => '/' ) );
 		switch_to_blog( $switch_site->blog_id );
 		$output_menu_script = true;
 	}


### PR DESCRIPTION
This also reduces the number of calls to the function and reuses
a `$nav_site` variable instead.

See https://github.com/washingtonstateuniversity/WSUWP-Platform/issues/351