### PR TITLE
[PR] Allow the WESKA site to have its own menu

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -14,7 +14,7 @@ include_once( __DIR__ . '/includes/shortcode-events.php' );
  * @return string Current script version
  */
 function wsu_cob_script_version() {
-	return spine_get_script_version() . '1.0.16';
+	return spine_get_script_version() . '1.0.17';
 }
 
 add_action( 'after_setup_theme', 'cob_theme_setup' );

--- a/spine/site-navigation.php
+++ b/spine/site-navigation.php
@@ -3,7 +3,7 @@
 	$output_menu_script = false;
 
 	$nav_site = get_site();
-	if ( '/' !== $nav_site->path && '/dividend/' !== $nav_site->path ) {
+	if ( '/' !== $nav_site->path && '/dividend/' !== $nav_site->path && '/weska/' !== $nav_site->path ) {
 		$switch_site = get_blog_details( array( 'domain' => $nav_site->domain, 'path' => '/' ) );
 		switch_to_blog( $switch_site->blog_id );
 		$output_menu_script = true;

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
  Author:         WSU University Communications
  Author URI:     https://web.wsu.edu/
  Template:       spine
- Version:        1.0.16
+ Version:        1.0.17
 */
 
 .fluidbox {


### PR DESCRIPTION
The site is currently at `stage.web.wsu.edu/weska/`. If I'm reading the condition right, this should be fine when the site goes live at `weska.wsu.edu`, too.